### PR TITLE
fix cache linebreak in ubuntu

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -90020,7 +90020,7 @@ function getVersion(uvExecutablePath) {
         };
         yield exec.exec(uvExecutablePath, execArgs, options);
         const parts = output.split(" ");
-        return parts[1];
+        return parts[1].trim();
     });
 }
 

--- a/src/download/download-latest.ts
+++ b/src/download/download-latest.ts
@@ -67,5 +67,5 @@ async function getVersion(uvExecutablePath: string): Promise<string> {
   };
   await exec.exec(uvExecutablePath, execArgs, options);
   const parts = output.split(" ");
-  return parts[1];
+  return parts[1].trim();
 }


### PR DESCRIPTION
Related https://github.com/astral-sh/setup-uv/issues/106

We can see the differences `uv --version` in different platforms:

OSX: uv 0.4.20 (0e1b25a53 2024-10-08)\n
Linux: uv 0.4.20\n

In getVersion function we split the output by space and return the second part.
This commit trims the version number to remove the line break.